### PR TITLE
Fixed "Scrape succeeded, but update failed" error

### DIFF
--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -222,7 +222,7 @@ def getPerformer(name):
             logging.error('ThePornDB HTTP Error: %s' % result.status_code)
             return None
         if next(iter(result.json().get("data", [{}])), {}).get("id", None):
-            performer_id = result["data"][0]["id"]
+            performer_id = result.json()["data"][0]["id"]
             return requests.get(data_url_prefix + performer_id, proxies=config.proxies).json()["data"]
         else:
             return None


### PR DESCRIPTION
Fixed an error in the code found by me (and fixed by bnkai) where the script was getting a "Scrape succeeded, but update failed" error when trying to scrape a scene where the site performer differs from the parent performer (ie. Lea Lexis site performer and Lea Lexus parent performer). This code change has been tested and now scrapes as it's supposed to.