### PR TITLE
Support filter for organized and scenes with a stash_id

### DIFF
--- a/SAMPLE_configuration.py
+++ b/SAMPLE_configuration.py
@@ -29,7 +29,7 @@ set_title = True
 set_url = True
 
 #PornDB API Key
-tpdb_api_key = "" # Optional Add your API Key here eg tpdb_api_key = "myactualapikey"
+tpdb_api_key = "" # Add your API Key here eg tpdb_api_key = "myactualapikey"
 
 #Set what content we add to Stash, if found in ThePornDB but not in Stash
 add_studio = True  

--- a/SAMPLE_configuration.py
+++ b/SAMPLE_configuration.py
@@ -15,6 +15,8 @@ rescrape_scenes= False # If False, script will not rescrape scenes previously sc
 retry_unmatched = False # If False, script will not rescrape scenes previously unmatched.  Must set unmatched_tag for this to work
 background_size = 'full' # Which size get from API, available options: full, large, medium, small
 debug_mode = False
+scrape_organized = False # If False, script will not scrape scenes set as Organized
+scrape_stash_id = False # If False, script will not scrape scenes that have a stash_id
 
 #Set what fields we scrape
 set_details = True

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -1076,14 +1076,11 @@ def main(args):
                 else:
                     logging.error("Did not find tag in Stash: " + tag_name, exc_info=config.debug_mode)
             
-            if (not config.scrape_stash_id) and config.scrape_organized: # scrape organized scenes not scenes with a stash_id
-                findScenes_params_incl['scene_filter'] = { 'tags': { 'modifier': 'INCLUDES', 'value': [*required_tag_ids] }, 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
-            elif config.scrape_stash_id and (not config.scrape_organized): # scrape scenes with a stash_id not organized ones
-                findScenes_params_excl['scene_filter'] = { 'tags': { 'modifier': 'INCLUDES', 'value': [*required_tag_ids] }, 'organized': False }
-            elif (not config.scrape_stash_id) and (not config.scrape_organized): # scrape scenes that arent organized and don't have a stash_id
-                findScenes_params_incl['scene_filter'] = { 'tags': { 'modifier': 'INCLUDES', 'value': [*required_tag_ids] }, 'organized': False, 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
-            else:
-                findScenes_params_incl['scene_filter'] = {'tags': {'modifier': 'INCLUDES','value': [*required_tag_ids]}}
+            findScenes_params_incl['scene_filter']['tags'] = { 'modifier': 'INCLUDES','value': [*required_tag_ids] }
+            if (not config.scrape_stash_id): # include only scenes without stash_id
+                findScenes_params_incl['scene_filter']['stash_id'] = { 'modifier': 'IS_NULL', 'value': 'none' }
+            if (not config.scrape_organized): # include only scenes that are not organized
+                findScenes_params_incl['scene_filter']['organized'] = False
             
             if len(excluded_tags) > 0:
                 print("Getting Scenes With Required Tags")
@@ -1092,7 +1089,6 @@ def main(args):
 
         #Set our filter to exclude any excluded_tags
         if len(excluded_tags) > 0:
-            print("Excluded tags")
             findScenes_params_excl = copy.deepcopy(findScenes_params)
             excluded_tag_ids = []
             for tag_name in excluded_tags:
@@ -1102,14 +1098,11 @@ def main(args):
                 else:
                     logging.error("Did not find tag in Stash: " + tag_name, exc_info=config.debug_mode)
             
-            if (not config.scrape_stash_id) and config.scrape_organized: # scrape organized scenes not scenes with a stash_id
-                findScenes_params_excl['scene_filter'] = { 'tags': { 'modifier': 'EXCLUDES', 'value': [*excluded_tag_ids] }, 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
-            elif config.scrape_stash_id and (not config.scrape_organized): # scrape scenes with a stash_id not organized ones
-                findScenes_params_excl['scene_filter'] = { 'tags': { 'modifier': 'EXCLUDES', 'value': [*excluded_tag_ids] }, 'organized': False }
-            elif (not config.scrape_stash_id) and (not config.scrape_organized): # scrape scenes that arent organized and don't have a stash_id
-                findScenes_params_excl['scene_filter'] = { 'tags': { 'modifier': 'EXCLUDES', 'value': [*excluded_tag_ids] }, 'organized': False, 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
-            else:
-                findScenes_params_excl['scene_filter'] = { 'tags': { 'modifier': 'EXCLUDES', 'value': [*excluded_tag_ids] }}
+            findScenes_params_excl['scene_filter']['tags'] = { 'modifier': 'EXCLUDES', 'value': [*excluded_tag_ids] }
+            if (not config.scrape_stash_id): # include only scenes without stash_id
+                findScenes_params_excl['scene_filter']['stash_id'] = { 'modifier': 'IS_NULL', 'value': 'none' }
+            if (not config.scrape_organized): # include only scenes that are not organized
+                findScenes_params_excl['scene_filter']['organized'] = False
 
             if len(required_tags) > 0:
                 print("Getting Scenes Without Excluded Tags")
@@ -1119,12 +1112,10 @@ def main(args):
         if len(excluded_tags) == 0 and len(
                 required_tags) == 0:  #If no tags are required or excluded
             findScenes_params_filtered = copy.deepcopy(findScenes_params)
-            if (not config.scrape_stash_id) and config.scrape_organized: # scrape organized scenes not scenes with a stash_id
-                findScenes_params_filtered['scene_filter'] = { 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
-            elif config.scrape_stash_id and (not config.scrape_organized): # scrape scenes with a stash_id not organized ones
-                findScenes_params_filtered['scene_filter'] = { 'organized': False }
-            elif (not config.scrape_stash_id) and (not config.scrape_organized): # scrape scenes that arent organized and don't have a stash_id
-                findScenes_params_filtered['scene_filter'] = { 'organized': False, 'stash_id': { 'modifier': 'IS_NULL', 'value': 'none' }}
+            if (not config.scrape_stash_id): # include only scenes without stash_id
+                findScenes_params_filtered['scene_filter']['stash_id'] = { 'modifier': 'IS_NULL', 'value': 'none' }
+            if (not config.scrape_organized): # include only scenes that are not organized
+                findScenes_params_filtered['scene_filter']['organized'] = False
             scenes = my_stash.findScenes(**findScenes_params_filtered)
 
         if len(required_tags) > 0 and len(excluded_tags) > 0:

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -1066,7 +1066,6 @@ def main(args):
 
         #Set our filter to require any required_tags
         if len(required_tags) > 0:
-            print("Required tags")
             findScenes_params_incl = copy.deepcopy(findScenes_params)
             required_tag_ids = []
             for tag_name in required_tags:

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -730,7 +730,7 @@ class config_class:
     set_url = True
 
     #ThePornDB API Key
-    tpdb_api_key = "" # Optional / Add your API Key here eg tbdb_api_key = "myactualapikey"
+    tpdb_api_key = "" # Add your API Key here eg tbdb_api_key = "myactualapikey"
 
     #Set what content we add to Stash, if found in ThePornDB but not in Stash
     add_studio = True
@@ -1021,6 +1021,9 @@ def main(args):
         if config.tpdb_api_key != "":
             tpdb_headers['Authorization'] = 'Bearer ' + config.tpdb_api_key
             logging.info('API Key found for TPDB')
+        else:
+            print("TPDB API Key not set. Exiting.")
+            return
 
         query_args = parseArgs(args)
         if len(query_args) == 1:
@@ -1119,7 +1122,11 @@ def main(args):
 
         if len(required_tags) > 0 and len(excluded_tags) > 0:
             scenes = [ scene for scene in scenes_with_tags if scene in scenes_without_tags]  #Scenes that exist in both
-
+        
+        if (not config.scrape_organized):
+            print("Skipped Organized scenes")
+        if (not config.scrape_stash_id):
+            print("Skipped scenes with a stash_id")
         print("Scenes to scrape", str(len(scenes)))
 
         for scene in scenes:


### PR DESCRIPTION
 Adds two more configuration options `scrape_stash_id` and `scrape_organized`.
`scrape_stash_id` if set to false (which is the default) skips scenes that have a stash_id. Those are scenes that were already matched using stashdb so most users probably dont need to rescrape them
`scrape_organized` if set to false (also the default) skips scenes that have the `organized` field set. Having a scene as organized should mean that the scene is complete/done so there shouldnt be a case where we want to have `scrape_organized` = True but the option is there if needed

If a TPDB API  key is not provided the script will now exit as users encounter 400 errors now if they dont fill in their API key.