### PR TITLE
Adding a "Prefer Filename Date" option, and tweaking dates that Stash…

### DIFF
--- a/StashInterface.py
+++ b/StashInterface.py
@@ -5,6 +5,7 @@ import math
 import re
 import sys
 import time
+import dateparser
 from datetime import datetime
 
 import requests
@@ -642,6 +643,30 @@ class stash_interface:
             self.addTag(stash_tag)
             return self.getTagByName(name)
 
+        return None
+
+    def getFileDate(self, scenepath):
+        regex_list = [
+            [r'[^\d]([012][0-9])[^\d]?(?:(0[1-9])|(1[0-2]))[^\d]?([0-3][0-9])[^\d]', '%y-%m-%d'],
+            [r'[^\d](?:(20[012][0-9])|(19[789][0-9]))[^\d]?(?:(0[1-9])|(1[0-2]))[^\d]?([0-3][0-9])[^\d]', '%Y-%m-%d'],
+            [r'[^\d]([23][0-9])[^\d]?(?:(0[1-9])|(1[0-2]))[^\d]?([012][0-9])[^\d]', '%d-%m-%y'],
+            [r'[^\d]([23][0-9])[^\d]?(?:(0[1-9])|(1[0-2]))[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%d-%m-%Y'],
+            [r'[^\d](?:(0[1-9])|(1[0-2]))[^\d]?([0-3][0-9])[^\d]?([012][0-9])[^\d]', '%m-%d-%y'],
+            [r'[^\d](?:(0[1-9])|(1[0-2]))[^\d]?([0-3][0-9])[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%m-%d-%Y'],
+            [r'[^\d]([0-3]?[0-9])[^\d]?(\w{3}?)[,]?[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%m-%b-%Y'],
+            [r'[^\d]([0-3]?[0-9])[^\d]?(\w{4,9}?)[,]?[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%m-%B-%Y'],
+            [r'[^\w](\w{3}?)[^\w]?([0-3]?[0-9])[,]?[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%b-%m-%Y'],
+            [r'[^\w](\w{4,9}?)[^\w]?([0-3]?[0-9])[,]?[^\d]?(?:(20[012][0-9])|(19[789][0-9]))[^\d]', '%B-%m-%Y'],
+        ]
+        for regex in regex_list:
+            if re.search(regex[0], scenepath):
+                filedate = re.search(regex[0], scenepath)
+                datearray = []
+                for group in filedate.groups():
+                    if group:
+                        datearray.append(group)
+                filedate = "-".join(datearray)
+                return dateparser.parse(filedate, date_formats=[regex[1]]).strftime("%Y-%m-%d")
         return None
 
     @staticmethod

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -173,7 +173,7 @@ def getBabepediaImage(name):
 
 
 def getTpbdImage(name):
-    url = "https://metadataapi.net/api/performers?q=" + urllib.parse.quote(name)
+    url = "https://metadataapi.net/performers?q=" + urllib.parse.quote(name)
     time.sleep(tpdb_sleep)
     r = requests.get(url, proxies=config.proxies, timeout=(3, 5), headers=tpdb_headers)
     if r.status_code >= 400:
@@ -222,8 +222,8 @@ def getPerformerImageB64(name):  # Searches Babepedia and TPBD for a performer i
 
 def getPerformer(name):
     global tpdb_headers, tpbd_error_count
-    search_url = "https://api.metadataapi.net/api/performers?q=" + urllib.parse.quote(name)
-    data_url_prefix = "https://api.metadataapi.net/api/performers/"
+    search_url = "https://api.metadataapi.net/performers?q=" + urllib.parse.quote(name)
+    data_url_prefix = "https://api.metadataapi.net/performers/"
     try:
         time.sleep(tpdb_sleep)  # sleep before every request to avoid being blocked
         result = requests.get(search_url, proxies=config.proxies, timeout=(3, 5), headers=tpdb_headers)
@@ -246,7 +246,7 @@ def getPerformer(name):
 
 def sceneHashQuery(oshash):  # Scrapes ThePornDB based on oshash.  Returns an array of scenes as results, or None
     global tpdb_headers, tpbd_error_count
-    url = "https://api.metadataapi.net/api/scenes?hash=" + urllib.parse.quote(oshash)
+    url = "https://api.metadataapi.net/scenes?hash=" + urllib.parse.quote(oshash)
     try:
         time.sleep(tpdb_sleep)  # sleep before every request to avoid being blocked
         result = requests.get(url, proxies=config.proxies, timeout=(3, 5), headers=tpdb_headers)
@@ -270,9 +270,9 @@ def sceneQuery(query, parse_function=True):  # Scrapes ThePornDB based on query.
     if custom_sceneQuery is not None:
         query = custom_sceneQuery(query)
     if parse_function:
-        url = "https://api.metadataapi.net/api/scenes?parse=" + urllib.parse.quote(query)
+        url = "https://api.metadataapi.net/scenes?parse=" + urllib.parse.quote(query)
     else:
-        url = "https://api.metadataapi.net/api/scenes?q=" + urllib.parse.quote(query)
+        url = "https://api.metadataapi.net/scenes?q=" + urllib.parse.quote(query)
     try:
         # TPDB seems to work better with YYYY-MM-DD instead of YYYYMMDD
         url = url.replace("%20", " ")
@@ -509,7 +509,7 @@ def scrapeScene(scene):
         if scraped_data:
             scraped_scene = scraped_data[0]
             try:
-                scraped_scene = requests.get('https://api.metadataapi.net/api/scenes/' + scraped_scene['id'], proxies=config.proxies, headers=tpdb_headers).json()["data"]
+                scraped_scene = requests.get('https://api.metadataapi.net/scenes/' + scraped_scene['id'], proxies=config.proxies, headers=tpdb_headers).json()["data"]
             except:
                 logging.error("Exception encountered when getting scene by id '" + scraped_scene['id'], exc_info=config.debug_mode)
                 pass

--- a/scrapeScenes.py
+++ b/scrapeScenes.py
@@ -836,7 +836,8 @@ class config_class:
     clean_filename = True  # If True, will try to clean up filenames before attempting scrape. Often unnecessary, as ThePornDB already does this
     compact_studio_names = True  # If True, this will remove spaces from studio names added from ThePornDB
     fail_no_date = False  # If True, on a failed scrape the system will attempt to remove the date from the query and try a re-scrape
-    prefer_file_date = False  # If True, will use the regex date from filename if less than the date on TPDB.  (Many TPDB dates are date of import rather than release date since the website may not list the release date)   ** VERIFY DATE REGEXES ARE GOOD FOR YOUR IMPORT FILES BEFORE ENABLING! **
+    prefer_file_date = True  # If True, will use the regex date from filename if less than the date on TPDB.  (Many TPDB dates are date of import rather than release date since the website may not list the release date)
+        #  Please note, prefer_fail_date (or -pfd on cli) should be used with the 'fail_no_date' (-fnd) option.  This is because if the date on TPDB and the filename are out of sync you won't get a match based on date ** VERIFY DATE REGEXES ARE GOOD FOR YOUR IMPORT FILES BEFORE ENABLING! **
     remove_search_tag = False  # If True, this will remove tags that are used for manual scraping on a successful scrape.  BE VERY CAREFUL WITH THIS FLAG!
     proxies = {}  # Leave empty or specify proxy like this: {'http':'http://user:pass@10.10.10.10:8000','https':'https://user:pass@10.10.10.10:8000'}
     path_include = False  # filepath to scrape.  This is pointing to path in the already existing Stash database entry, and isn't an import process
@@ -1014,7 +1015,7 @@ def parseArgs(args):
     my_parser.add_argument('-pfd',
                            '--prefer_file_date',
                            action='store_true',
-                           help='prefer date from file if lower than TPDB returned date')
+                           help='prefer date from file if lower than TPDB returned date.  (should be used with -fnd|--fail_no_date option)')
     my_parser.add_argument(
         '-t',
         '--tags',


### PR DESCRIPTION
… can't find

TPDB scrapers use the date of import for sites that don't have dates listed.  Obviously those can be much later than the actual release, however the releases tend to include a much closer date to the actual release date.  With this there's an optional config flag "prefer_file_date" (or -pfd on cli) to say "If the date in the filename is before the scraped date, then use the filename date instead"

Also a small date tweak to parse dates out of the filename that Stash doesn't pull correctly on its import